### PR TITLE
V1.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fhir-snapshot-generator",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fhir-snapshot-generator",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "dependencies": {
         "fhir-package-explorer": "^1.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-snapshot-generator",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Generate snapshots for FHIR Profiles",
   "main": "dist/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
Implemented failed expansion caching: failed ValueSet expansions without fallback now store a stub (expansion with timestamp + __failure=true) so subsequent requests short-circuit immediately.